### PR TITLE
feat: 屏蔽指定用户UID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilibili-live-chat",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/Live.vue
+++ b/src/components/Live.vue
@@ -29,6 +29,9 @@ export default {
     const giftCombMap = new Map();
     const giftShowFace = computed(() => !['false', 'gift'].includes(props.face));
 
+    const blockUIDs = computed(() => new Set(props.blockUID.split('|').map(uid => uid.trim())));
+    const isBlockedUID = uid => blockUIDs.value.has(String(uid));
+
     const addInfoDanmaku = message => {
       danmakuList.value.addDanmaku({
         type: 'info',
@@ -59,8 +62,8 @@ export default {
       // 礼物
       const giftList = props.giftPin ? giftPinList : danmakuList;
       live.on('SEND_GIFT', ({ data: { uid, uname, action, giftName, num, face } }) => {
-        if (props.blockUID.split("|").lastIndexOf(Number(uid).toString()) != -1) {
-          console.log("屏蔽了来自[" + uname + "]的礼物: " + giftName + " " + num + "个");
+        if (isBlockedUID(uid)) {
+          console.log(`屏蔽了来自[${uname}]的礼物：${giftName}*${num}`);
           return;
         }
         setFace(uid, face);
@@ -102,8 +105,8 @@ export default {
 
       // 弹幕
       live.on('DANMU_MSG', ({ info: [, message, [uid, uname, isOwner /*, isVip, isSvip*/]] }) => {
-        if (props.blockUID.split("|").lastIndexOf(Number(uid).toString()) != -1) {
-          console.log("屏蔽了来自[" + uname + "]的弹幕: " + message);
+        if (isBlockedUID(uid)) {
+          console.log(`屏蔽了来自[${uname}]的弹幕：${message}`);
           return;
         }
         const danmaku = {

--- a/src/components/Live.vue
+++ b/src/components/Live.vue
@@ -59,6 +59,10 @@ export default {
       // 礼物
       const giftList = props.giftPin ? giftPinList : danmakuList;
       live.on('SEND_GIFT', ({ data: { uid, uname, action, giftName, num, face } }) => {
+        if (props.blockUID.split("|").lastIndexOf(Number(uid).toString()) != -1) {
+          console.log("屏蔽了来自[" + uname + "]的礼物: " + giftName + " " + num + "个");
+          return;
+        }
         setFace(uid, face);
         if (props.giftComb) {
           const key = `${uid}-${giftName}`;
@@ -98,6 +102,10 @@ export default {
 
       // 弹幕
       live.on('DANMU_MSG', ({ info: [, message, [uid, uname, isOwner /*, isVip, isSvip*/]] }) => {
+        if (props.blockUID.split("|").lastIndexOf(Number(uid).toString()) != -1) {
+          console.log("屏蔽了来自[" + uname + "]的弹幕: " + message);
+          return;
+        }
         const danmaku = {
           type: 'message',
           showFace: giftShowFace.value,

--- a/src/pages/index/App.vue
+++ b/src/pages/index/App.vue
@@ -116,6 +116,15 @@
           v-model.number="form.delay"
         />
       </input-group>
+      <!-- 屏蔽用户 -->
+      <input-group header="屏蔽用户" footer="">
+        <input
+          class="form-control"
+          type="text"
+          placeholder="选填，将不显示指定UID用户的弹幕和礼物，用竖杠|分隔"
+          v-model="form.blockUID"
+        />
+      </input-group>
     </div>
   </div>
 </template>

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -13,6 +13,7 @@ export const defaultProps = {
   giftComb: '',
   giftPin: '',
   delay: '',
+  blockUID: '',
 };
 Object.freeze(defaultProps);
 


### PR DESCRIPTION
近期发现有人利用打擦边球和带有违规广告的用户名ID来通过弹幕搞事情，我们已经深受其害。这些违规信息如果展示在直播画面上同样有被举报和封直播间的危险。因此不得不开发此**拉黑**功能。

此改动在首页设置页面最后追加了一个输入项，屏蔽指定UID的用户，UID可以输入多个，之间用竖杠”|“分隔。被屏蔽的用户发送弹幕或赠送礼物将不会在本网页弹幕姬中显示。

请大佬考虑一下。代码已经写好并自测通过。